### PR TITLE
Update SPECS-FHIR.xml

### DIFF
--- a/xml/SPECS-FHIR.xml
+++ b/xml/SPECS-FHIR.xml
@@ -159,5 +159,5 @@
   <specification key="us-medication-rems" name="US Medication Risk Evaluation and Mitigation Strategies (REMS) FHIR IG"/>
   <specification key="cardx-htn-mng" name="CardX Hypertension Management" accelerator="codex"/>
   <specification key="termchangeset" name="Terminology Change Set Exchange"/>
-  <specification key="uv-smart-health-cards-and-links" name="SMART Health Cards and Links"/>
+  <specification key="smart-health-cards-and-links" name="SMART Health Cards and Links"/>
 </specifications>


### PR DESCRIPTION
Remove "uv" from uv-smart-health-cards-and-links... to match Jira spec name expected by the publisher